### PR TITLE
Add link to synthetic churn dataset on Hugging Face

### DIFF
--- a/churn/ReadMe.md
+++ b/churn/ReadMe.md
@@ -43,6 +43,13 @@ While both models achieved the expected accuracy on our synthetic dataset, Light
 | 18 | SupportChannel           | object  |
 | 19 | HasChurned               | bool    |
 
+## Dataset
+
+The synthetic dataset used to train these models is available on Hugging Face:
+https://huggingface.co/datasets/Omer1234567/telco-churn-synthetic
+
+You can also regenerate it yourself with `01-telco-customer-churn-data-generator.py`. Note that the generator is not seeded, so re-running it produces different values, not an exact copy of the published dataset.
+
 ## Model Accuracy Results
 
 BalancedRandomForestClassifier Results:<br/>


### PR DESCRIPTION
Closes the gap reported in #28 — the synthetic dataset used to train the churn models in #11 was never committed to the repo. This adds a link to it on Hugging Face: https://huggingface.co/datasets/Omer1234567/telco-churn-synthetic

Also notes that the generator script isn't seeded, so re-running it won't reproduce the exact same data.