### PR TITLE
Add python version in the Readme file to avoid dependancy failure

### DIFF
--- a/churn/ReadMe.md
+++ b/churn/ReadMe.md
@@ -9,7 +9,7 @@ This project delivers an end‑to‑end Telecom Customer Churn Prediction soluti
 
 Both models are trained on rich, synthetic telecom datasets—incorporating usage patterns, billing details, and support interactions—to predict which customers are at highest risk of churn. By identifying high‑risk segments in advance, operators can deploy targeted retention offers and optimize churn‑prevention campaigns, ultimately safeguarding revenue and improving customer lifetime value.
 
-## Software-Requirement
+## Software Requirement
 
 | Software      | Version |
 |---------------|---------|

--- a/churn/ReadMe.md
+++ b/churn/ReadMe.md
@@ -9,6 +9,14 @@ This project delivers an end‑to‑end Telecom Customer Churn Prediction soluti
 
 Both models are trained on rich, synthetic telecom datasets—incorporating usage patterns, billing details, and support interactions—to predict which customers are at highest risk of churn. By identifying high‑risk segments in advance, operators can deploy targeted retention offers and optimize churn‑prevention campaigns, ultimately safeguarding revenue and improving customer lifetime value.
 
+## Software-Requirement
+
+| Software      | Version |
+|---------------|---------|
+| Python        | 3.12    |
+
+> Tested with Python 3.12 as the minimum version. Python 3.13 and later 3.x releases may work but have not been validated.
+
 ## Model Options
 
 Both the Balanced Random Forest and LightGBM classifiers are well‑suited for binary churn prediction, but they achieve this in different ways that are worth understanding:

--- a/revenueassurance/ReadMe.md
+++ b/revenueassurance/ReadMe.md
@@ -2,6 +2,7 @@
 
 - [Revenue Assurance and Fraud Management (RAFM) with AI Assistance](#Revenue-Assurance-and-Fraud-Management-\(RAFM\)-with-AI-Assistance)
   - [Project Overview](#Project-Overview)
+  - [Software requirement](#Software-Requirement)
   - [Options](#Options)
   - [Data](#Data)
   - [Results](#Results)
@@ -23,6 +24,14 @@ This project aims to deliver an RAFM prediction (if that particular telco transa
 The models are trained on synthetic telecom data to predict fraud cases and identify potential anomalies. The goal is to provide proactive revenue management and enhance revenue workflows.<br>
 
 Data-Set: https://huggingface.co/datasets/fenar/revenue_assurance
+
+## Software-Requirement
+
+| Software      | Version |
+|---------------|---------|
+| Python        | 3.12    |
+
+> Tested with Python 3.12 as the minimum version. Python 3.13 and later 3.x releases may work but have not been validated.
 
 ## Options 
 

--- a/revenueassurance/ReadMe.md
+++ b/revenueassurance/ReadMe.md
@@ -25,7 +25,7 @@ The models are trained on synthetic telecom data to predict fraud cases and iden
 
 Data-Set: https://huggingface.co/datasets/fenar/revenue_assurance
 
-## Software-Requirement
+## Software Requirement
 
 | Software      | Version |
 |---------------|---------|

--- a/serviceassurance/ReadMe.md
+++ b/serviceassurance/ReadMe.md
@@ -7,7 +7,7 @@ This project aims to deliver a service assurance insights (net promoter score -N
 
 **🎥 Demo Video**: [Watch on YouTube](https://youtu.be/gFbtux0dGVA) <br>
 
-## Software-Requirement
+## Software Requirement
 
 | Software      | Version |
 |---------------|---------|

--- a/serviceassurance/ReadMe.md
+++ b/serviceassurance/ReadMe.md
@@ -7,6 +7,14 @@ This project aims to deliver a service assurance insights (net promoter score -N
 
 **🎥 Demo Video**: [Watch on YouTube](https://youtu.be/gFbtux0dGVA) <br>
 
+## Software-Requirement
+
+| Software      | Version |
+|---------------|---------|
+| Python        | 3.12    |
+
+> Tested with Python 3.12 as the minimum version. Python 3.13 and later 3.x releases may work but have not been validated.
+
 ## Data
 ![Service Assurance Data Structure](https://raw.githubusercontent.com/fenar/etc-ai-wrx/main/serviceassurance/data/svcass-datainsp.png)<br>
 

--- a/starlink/README.md
+++ b/starlink/README.md
@@ -12,6 +12,14 @@ To empower travelers with insights into Starlink's internet service quality at t
     <img src="https://raw.githubusercontent.com/tme-osx/TME-AIX/refs/heads/RedHat-Special/starlink/images/starling-qoe-moods.png" width="640"/>
 </div>
 
+## Software-Requirement
+
+| Software      | Version |
+|---------------|---------|
+| Python        | 3.12    |
+
+> Tested with Python 3.12 as the minimum version. Python 3.13 and later 3.x releases may work but have not been validated.
+
 ## Data
 ![Data Structure](https://raw.githubusercontent.com/tme-osx/TME-AIX/refs/heads/main/starlink/images/starlink-data.png)<br>
 DataSet Location: https://huggingface.co/datasets/fenar/starlink

--- a/starlink/README.md
+++ b/starlink/README.md
@@ -12,7 +12,7 @@ To empower travelers with insights into Starlink's internet service quality at t
     <img src="https://raw.githubusercontent.com/tme-osx/TME-AIX/refs/heads/RedHat-Special/starlink/images/starling-qoe-moods.png" width="640"/>
 </div>
 
-## Software-Requirement
+## Software Requirement
 
 | Software      | Version |
 |---------------|---------|


### PR DESCRIPTION
Closes the gap reported in https://github.com/open-experiments/Telco-AIX/issues/31
Openshift AI can use custom workbench with supported Python release.
Openshift AI 3.4.2 default workbench support Python 3.12.